### PR TITLE
Use only lodash.flatmap instead of the whole lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const fsSync = require('fs')
 const findInFiles = require('find-in-files')
-const flatMap = require('lodash/flatMap')
+const flatMap = require('lodash.flatmap')
 
 /**
  * Find correct entry point based on access path

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-entrypoint-generator",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3296,7 +3296,13 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash.flatmap": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
+      "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-entrypoint-generator",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Entry point generator based on code for rollup",
   "main": "index.js",
   "repository": {
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "find-in-files": "~0.5.0",
-    "lodash": "~4.17.15"
+    "lodash.flatmap": "~4.5.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",


### PR DESCRIPTION
No need to use the whole lib, we can just import `lodash.flatMap` to reduce overall size